### PR TITLE
GHC 9.2 changes

### DIFF
--- a/ghc-tcplugins-extra.cabal
+++ b/ghc-tcplugins-extra.cabal
@@ -18,7 +18,8 @@ extra-source-files:  README.md
                      CHANGELOG.md
 cabal-version:       >=1.10
 tested-with:         GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4,
-                     GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.1
+                     GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.1,
+                     GHC == 9.2.1
 
 source-repository head
   type: git
@@ -33,7 +34,7 @@ flag deverror
 library
   exposed-modules:     GHC.TcPluginM.Extra
   build-depends:       base >=4.8  && <5,
-                       ghc  >=7.10 && <9.2
+                       ghc  >=7.10 && <9.4
   hs-source-dirs:      src
   default-language:    Haskell2010
   other-extensions:    CPP


### PR DESCRIPTION
The main change attempts to account for the removal of type family flattening variables. The `mkSubst` function now returns `Nothing` for a type family application (the equality now relates the type family application LHS with an arbitrary RHS, as opposed to a flattening variable LHS with the type family application RHS). I'm still trying to figure out the impact of the removal of flattening variables, it seems like it will be a simplification in some cases but potentially making things a lot more difficult in others. Let me know if you would prefer something different.    

I was also getting an incomplete record update in `substCt`, because it didn't account for quantified constraints. I've changed it to handle that constructor in the same way as the others.         

I tried to get the CPP right in order to retain maximum compatibility across GHC versions, but I haven't checked extensively. I only checked that the library compiles on GHC 8.6, 8.8, 8.10, 9.0 and 9.2.