### PR TITLE
Bump GHC upper bound from 9.6 to 9.8

### DIFF
--- a/ghc-tcplugins-extra.cabal
+++ b/ghc-tcplugins-extra.cabal
@@ -48,7 +48,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.8 && <5
-    , ghc >=7.10 && <9.6
+    , ghc >=7.10 && <9.8
   default-language: Haskell2010
   if impl(ghc >= 8.0.0)
     ghc-options: -Wcompat -Wincomplete-uni-patterns -Widentities -Wredundant-constraints
@@ -56,7 +56,7 @@ library
     ghc-options: -fhide-source-paths
   if flag(deverror)
     ghc-options: -Werror
-  if impl(ghc >= 9.4) && impl(ghc < 9.6)
+  if impl(ghc >= 9.4) && impl(ghc < 9.8)
     other-modules:
         GhcApi.Constraint
         GhcApi.Predicate
@@ -68,7 +68,7 @@ library
         src-ghc-tree-9.4
         src-ghc-9.4
     build-depends:
-        ghc >=9.4 && <9.6
+        ghc >=9.4 && <9.8
   if impl(ghc >= 9.2) && impl(ghc < 9.4)
     other-modules:
         GhcApi.Constraint

--- a/package.dhall
+++ b/package.dhall
@@ -26,11 +26,11 @@ in  let ghc = { name = "ghc", mixin = [] : List Text }
                 //  { library =
                       { source-dirs = "src"
                       , dependencies =
-                        [ "base >=4.8 && <5", "ghc >=7.10 && <9.6" ]
+                        [ "base >=4.8 && <5", "ghc >=7.10 && <9.8" ]
                       , exposed-modules = "GHC.TcPluginM.Extra"
                       , other-modules = "Internal"
                       , when =
-                        [ version "9.4" "9.6" [ "tree-9.4", "9.4" ] ghc mods
+                        [ version "9.4" "9.8" [ "tree-9.4", "9.4" ] ghc mods
                         , version "9.2" "9.4" [ "tree", "9.2" ] ghc mods
                         , version "9.0" "9.2" [ "tree", "9.0" ] ghc mods
                         , version "8.10" "9.0" [ "flat", "8.10" ] ghc mods


### PR DESCRIPTION
An I-don't-know-what-I'm-doing update to GHC 9.6. My code using the plugin compiles with --allow-newer and -O0. No head.hackage, just pure Hackage.
